### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "csangani"
+    groups:
+      actions-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "deps(actions)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,4 +20,4 @@ updates:
           - "minor"
           - "patch"
     commit-message:
-      prefix: "deps(actions)"
+      prefix: "chore(deps-actions)"


### PR DESCRIPTION
## Summary
- Add GitHub Actions ecosystem (only package manager in this repo)
- Configure `reviewers: ["csangani"]`
- Standard group naming and commit-message prefix

## Test plan
- [ ] Verify Dependabot picks up GitHub Actions ecosystem within 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)